### PR TITLE
Fix auth.example.js callback

### DIFF
--- a/server/config/auth.example.js
+++ b/server/config/auth.example.js
@@ -1,20 +1,9 @@
 module.exports = {
 
   'facebookAuth' : {
-      'clientID'      : 'your App ID',
-      'clientSecret'  : 'clientsecretID',
-      'callbackURL'   : 'http://localhost:3000/auth/facebook/return'
+    'clientID'      : 'CLIENT ID',
+    'clientSecret'  : 'CLIENT SECRET',
+    'callbackURL'   : 'http://localhost:3000/login/facebook/return'
   },
 
-  'twitterAuth' : {
-      'consumerKey'       : 'your-consumer-key-here',
-      'consumerSecret'    : 'your-client-secret-here',
-      'callbackURL'       : 'http://localhost:8080/auth/twitter/callback'
-  },
-
-  'googleAuth' : {
-      'clientID'      : 'your-secret-clientID-here',
-      'clientSecret'  : 'your-client-secret-here',
-      'callbackURL'   : 'http://localhost:8080/auth/google/callback'
-  }
 };


### PR DESCRIPTION
I removed the Google and Twitter auth for now, just because we don't know if those are the correct URLs, and we might not remember that in the future.
