### PR TITLE
Browser and IP-based geolocation

### DIFF
--- a/public/js/services/LocationService.js
+++ b/public/js/services/LocationService.js
@@ -35,7 +35,17 @@ angular.module('LocationService', [])
     });
   };
 
+  var ip = function() {
+    return $q(function(resolve, reject) {
+      $http.get('http://freegeoip.net/json/')
+        .success(function(res) {
+          resolve(res.city + ', ' + res.region_code);
+        }).error(reject);
+    });
+  };
+
   return {
-    browser: browser
+    browser: browser,
+    ip: ip,
   };
 }]);

--- a/public/js/services/LocationService.js
+++ b/public/js/services/LocationService.js
@@ -1,0 +1,41 @@
+angular.module('LocationService', [])
+
+.factory('Location', ['$q', '$window', '$http', function($q, $window, $http) {
+
+  var geoLocate = function() {
+    return $q(function(resolve, reject) {
+      if('geolocation' in $window.navigator) {
+        $window.navigator.geolocation.getCurrentPosition(function(position) {
+          resolve({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+          });
+        }, reject);
+      } else {
+        reject(new Error('Geolocation is not supported'));
+      }
+    });
+  };
+
+  var reverseGeocode = function(coords) {
+    return $q(function(resolve, reject) {
+      var url = 'http://maps.google.com/maps/api/geocode/json?latlng=';
+      url += coords.lat + ',' + coords.lng;
+      $http.get(url).success(resolve).error(reject);
+    });
+  };
+
+  var browser = function() {
+    return $q(function(resolve, reject) {
+      geoLocate()
+        .then(reverseGeocode, reject)
+        .then(function(reversed) {
+          resolve(reversed.results[0].formatted_address);
+        });
+    });
+  };
+
+  return {
+    browser: browser
+  };
+}]);


### PR DESCRIPTION
Added `Location` Service, with two exported methods:
- `browser`, which (upon prompting the user) returns a formatted address string from Google
- `ip`, which uses freegeoip.net to estimate and return a string of "City, Region"

First half of #21 
